### PR TITLE
[Fix/27] 화면 padding 값을 조정합니다.

### DIFF
--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/topbar/CenterTitleTopBar.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/topbar/CenterTitleTopBar.kt
@@ -5,8 +5,11 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,6 +37,7 @@ fun CenterTitleTopBar(
 ) {
     Box(
         modifier = modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
             .aspectRatio(7.5f)
             .fillMaxWidth()
     ) {

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/topbar/StartTitleTopBar.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/topbar/StartTitleTopBar.kt
@@ -4,8 +4,11 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +31,7 @@ fun StartTitleTopBar(
 ) {
     Row(
         modifier = modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
             .aspectRatio(7.5f)
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouplist/navigation/GroupListNavGraph.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouplist/navigation/GroupListNavGraph.kt
@@ -1,5 +1,6 @@
 package com.sopt.gongbaek.presentation.ui.grouplist.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -9,14 +10,16 @@ import com.sopt.gongbaek.presentation.ui.grouplist.screen.GroupListRoute
 import com.sopt.gongbaek.presentation.ui.groupregister.navigation.navigateGroupRegisterNavGraph
 
 fun NavGraphBuilder.groupListNavGraph(
-    navController: NavHostController
+    navController: NavHostController,
+    innerPadding: PaddingValues
 ) {
     composable<MainBottomTabRoute.GroupList> {
         GroupListRoute(
             navigateGroupDetail = { groupId, groupCycle ->
                 navController.navigateGroupDetail(groupId, groupCycle)
             },
-            navigateGroupRegister = navController::navigateGroupRegisterNavGraph
+            navigateGroupRegister = navController::navigateGroupRegisterNavGraph,
+            innerPadding = innerPadding
         )
     }
 }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouplist/screen/GroupListScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouplist/screen/GroupListScreen.kt
@@ -4,14 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -19,7 +17,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,7 +51,8 @@ import com.sopt.gongbaek.ui.theme.GongBaekTheme
 fun GroupListRoute(
     viewModel: GroupListViewModel = hiltViewModel(),
     navigateGroupDetail: (Int, String) -> Unit,
-    navigateGroupRegister: () -> Unit
+    navigateGroupRegister: () -> Unit,
+    innerPadding: PaddingValues
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -95,7 +93,8 @@ fun GroupListRoute(
         navigateGroupRegister = {
             viewModel.sendSideEffect(GroupListContract.SideEffect.NavigateGroupRegister)
         },
-        groupList = uiState.groups
+        groupList = uiState.groups,
+        modifier = Modifier.padding(innerPadding)
     )
 }
 
@@ -109,35 +108,14 @@ fun GroupListScreen(
     onToggleStateChanged: (Boolean) -> Unit,
     navigateGroupDetail: (Int, String) -> Unit,
     navigateGroupRegister: () -> Unit,
-    groupList: List<GroupInfo>
+    groupList: List<GroupInfo>,
+    modifier: Modifier = Modifier
 ) {
-    Scaffold(
-        modifier = Modifier
-            .padding(top = 10.dp)
-            .padding(WindowInsets.navigationBars.asPaddingValues()),
-        topBar = {
-            CenterTitleTopBar(R.string.topbar_group)
-        },
-        floatingActionButton = {
-            FloatingActionButton(
-                onClick = navigateGroupRegister,
-                shape = CircleShape,
-                containerColor = GongBaekTheme.colors.mainOrange
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_plus_24),
-                    contentDescription = null,
-                    tint = GongBaekTheme.colors.white
-                )
-            }
-        },
-        containerColor = GongBaekTheme.colors.white
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-        ) {
+    Box(
+        modifier = modifier.fillMaxSize()
+    ) {
+        Column {
+            CenterTitleTopBar(centerTitleResId = R.string.topbar_group)
             DayOfWeekBar(
                 selectedIndex = selectedDayOfWeekIndex,
                 onIndexSelected = onDayOfWeekSelected
@@ -220,6 +198,24 @@ fun GroupListScreen(
                     }
                 }
             }
+        }
+
+        FloatingActionButton(
+            onClick = navigateGroupRegister,
+            shape = CircleShape,
+            containerColor = GongBaekTheme.colors.mainOrange,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(
+                    end = 16.dp,
+                    bottom = 16.dp
+                )
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_plus_24),
+                contentDescription = null,
+                tint = GongBaekTheme.colors.white
+            )
         }
     }
 }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupregister/screen/GroupCoverScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupregister/screen/GroupCoverScreen.kt
@@ -1,6 +1,7 @@
 package com.sopt.gongbaek.presentation.ui.groupregister.screen
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -85,6 +86,7 @@ fun GroupCoverScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp)
             )
         },
+        contentWindowInsets = WindowInsets(0.dp),
         containerColor = GongBaekTheme.colors.white
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupregister/screen/GroupTimeScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupregister/screen/GroupTimeScreen.kt
@@ -1,6 +1,7 @@
 package com.sopt.gongbaek.presentation.ui.groupregister.screen
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -88,6 +89,7 @@ fun GroupTimeScreen(
                     .padding(horizontal = 16.dp, vertical = 12.dp)
             )
         },
+        contentWindowInsets = WindowInsets(0.dp),
         containerColor = GongBaekTheme.colors.white
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/navigation/HomeNavGraph.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/navigation/HomeNavGraph.kt
@@ -1,5 +1,6 @@
 package com.sopt.gongbaek.presentation.ui.home.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -10,7 +11,8 @@ import com.sopt.gongbaek.presentation.ui.grouproom.navigation.navigateGroupRoom
 import com.sopt.gongbaek.presentation.ui.home.screen.HomeRoute
 
 fun NavGraphBuilder.homeNavGraph(
-    navController: NavHostController
+    navController: NavHostController,
+    innerPadding: PaddingValues
 ) {
     composable<MainBottomTabRoute.Home> {
         HomeRoute(
@@ -20,7 +22,8 @@ fun NavGraphBuilder.homeNavGraph(
             navigateGroupRoom = { groupId, groupType ->
                 navController.navigateGroupRoom(groupId, groupType)
             },
-            navigateGroupList = navController::navigateGroupList
+            navigateGroupList = navController::navigateGroupList,
+            innerPadding = innerPadding
         )
     }
 }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
@@ -1,23 +1,18 @@
 package com.sopt.gongbaek.presentation.ui.home.screen
 
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import androidx.lifecycle.flowWithLifecycle
 import com.sopt.gongbaek.domain.model.NearestGroup
 import com.sopt.gongbaek.domain.model.RecommendGroupInfo
@@ -33,6 +28,7 @@ fun HomeRoute(
     navigateGroupDetail: (Int, String) -> Unit,
     navigateGroupRoom: (Int, String) -> Unit,
     navigateGroupList: () -> Unit,
+    innerPadding: PaddingValues,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -79,7 +75,8 @@ fun HomeRoute(
         },
         navigateGroupRoom = { groupId, groupType ->
             viewModel.sendSideEffect(HomeContract.SideEffect.NavigateToGroupRoom(groupId, groupType))
-        }
+        },
+        modifier = Modifier.padding(innerPadding)
     )
 }
 
@@ -93,24 +90,11 @@ private fun HomeScreen(
     onClickWeekRecommendItem: (Int, String) -> Unit,
     onClickOnceRecommendItem: (Int, String) -> Unit,
     onFillGroupClick: () -> Unit,
-    navigateGroupRoom: (Int, String) -> Unit
+    navigateGroupRoom: (Int, String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    val systemUiController = rememberSystemUiController()
-
-    DisposableEffect(Unit) {
-        systemUiController.setStatusBarColor(
-            color = Color.Transparent,
-            darkIcons = true
-        )
-        onDispose {
-        }
-    }
-
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(WindowInsets.navigationBars.asPaddingValues())
-            .padding(WindowInsets.navigationBars.asPaddingValues())
+        modifier = modifier.fillMaxSize()
     ) {
         item {
             NearestGroupSection(

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainBottomNavBar.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainBottomNavBar.kt
@@ -73,7 +73,7 @@ private fun MainBottomNavBarItem(
     Column(
         modifier = modifier
             .clickableWithoutRipple(onClick = onClick)
-            .padding(vertical = 14.dp),
+            .padding(vertical = 8.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -87,7 +87,7 @@ private fun MainBottomNavBarItem(
             ),
             contentDescription = null
         )
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = context.getString(bottomNavBarTabType.label),
             style = GongBaekTheme.typography.body2.m14,

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
@@ -59,7 +59,10 @@ fun MainNavHost(
         composable<NavigationRoute.TermsOfService> { TermsOfServiceRoute(navController = navigator.navController) }
         onboardingNavGraph(navigator.navController)
         authNavGraph(navigator.navController)
-        groupListNavGraph(navigator.navController)
+        groupListNavGraph(
+            navController = navigator.navController,
+            innerPadding = paddingValues
+        )
         groupRegisterNavGraph(navigator.navController)
         groupDetailNavGraph(navigator.navController)
         homeNavGraph(

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
@@ -1,20 +1,12 @@
 package com.sopt.gongbaek.presentation.ui.main
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import com.sopt.gongbaek.presentation.model.MainBottomTabRoute
 import com.sopt.gongbaek.presentation.model.NavigationRoute
 import com.sopt.gongbaek.presentation.ui.auth.navigation.authNavGraph
 import com.sopt.gongbaek.presentation.ui.groupdetail.navigation.groupDetailNavGraph
@@ -34,25 +26,10 @@ fun MainNavHost(
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
-    val currentBackStackEntry by navigator.navController.currentBackStackEntryAsState()
-    val isNoStatusBarPaddingRoute = listOf(
-        currentBackStackEntry?.destination?.hasRoute<MainBottomTabRoute.Home>(),
-        currentBackStackEntry?.destination?.hasRoute<NavigationRoute.GroupRoom>(),
-        currentBackStackEntry?.destination?.hasRoute<NavigationRoute.Login>()
-    ).any { it == true }
-
     NavHost(
         navController = navigator.navController,
         startDestination = navigator.startDestination,
-        modifier = modifier
-            .fillMaxSize()
-            .padding(
-                if (isNoStatusBarPaddingRoute) {
-                    PaddingValues(0.dp)
-                } else {
-                    WindowInsets.statusBars.asPaddingValues()
-                }
-            )
+        modifier = modifier.fillMaxSize()
     ) {
         composable<NavigationRoute.Splash> { SplashRoute(navController = navigator.navController) }
         composable<NavigationRoute.Login> { SocialLoginRoute(navController = navigator.navController) }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
@@ -67,6 +67,9 @@ fun MainNavHost(
             innerPadding = paddingValues
         )
         groupRoomNavGraph(navigator.navController)
-        myPageNavGraph(navigator.navController)
+        myPageNavGraph(
+            navController = navigator.navController,
+            innerPadding = paddingValues
+        )
     }
 }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainNavHost.kt
@@ -62,7 +62,10 @@ fun MainNavHost(
         groupListNavGraph(navigator.navController)
         groupRegisterNavGraph(navigator.navController)
         groupDetailNavGraph(navigator.navController)
-        homeNavGraph(navigator.navController)
+        homeNavGraph(
+            navController = navigator.navController,
+            innerPadding = paddingValues
+        )
         groupRoomNavGraph(navigator.navController)
         myPageNavGraph(navigator.navController)
     }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/main/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.sopt.gongbaek.presentation.type.MainBottomNavBarTabType
 import com.sopt.gongbaek.ui.theme.GongBaekTheme
 
@@ -28,6 +29,7 @@ fun MainScreen(
                 onBottomNavBarTabSelected = { navigator.navigate(it) }
             )
         },
+        contentWindowInsets = WindowInsets(0.dp),
         containerColor = GongBaekTheme.colors.white,
         content = { paddingValues ->
             MainNavHost(

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/mypage/navigation/MyPageNavGraph.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/mypage/navigation/MyPageNavGraph.kt
@@ -1,5 +1,6 @@
 package com.sopt.gongbaek.presentation.ui.mypage.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -11,7 +12,8 @@ import com.sopt.gongbaek.presentation.ui.mypage.screen.MyPageRoute
 import com.sopt.gongbaek.presentation.ui.mypage.screen.SettingRoute
 
 fun NavGraphBuilder.myPageNavGraph(
-    navController: NavController
+    navController: NavController,
+    innerPadding: PaddingValues
 ) {
     composable<MainBottomTabRoute.MyPage> {
         MyPageRoute(
@@ -23,7 +25,8 @@ fun NavGraphBuilder.myPageNavGraph(
             },
             navigateGroupRoom = { groupId, groupCycle ->
                 navController.navigateGroupRoom(groupId, groupCycle)
-            }
+            },
+            innerPadding = innerPadding
         )
     }
 

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/mypage/screen/MyPageScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/mypage/screen/MyPageScreen.kt
@@ -2,14 +2,12 @@ package com.sopt.gongbaek.presentation.ui.mypage.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
@@ -48,7 +46,8 @@ fun MyPageRoute(
     viewModel: MyPageViewModel = hiltViewModel(),
     navigateSetting: () -> Unit,
     navigateGroupDetail: (Int, String) -> Unit,
-    navigateGroupRoom: (Int, String) -> Unit
+    navigateGroupRoom: (Int, String) -> Unit,
+    innerPadding: PaddingValues
 ) {
     val myPageUiState by viewModel.state.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -75,6 +74,7 @@ fun MyPageRoute(
                     is MyPageContract.SideEffect.NavigateGroupRoom -> {
                         navigateGroupRoom(sideEffect.groupId, sideEffect.groupCycle)
                     }
+
                     else -> {}
                 }
             }
@@ -92,7 +92,8 @@ fun MyPageRoute(
         },
         onGroupRoomButtonClick = { groupId, groupCycle ->
             viewModel.sendSideEffect(MyPageContract.SideEffect.NavigateGroupRoom(groupId, groupCycle))
-        }
+        },
+        modifier = Modifier.padding(innerPadding)
     )
 }
 
@@ -103,12 +104,12 @@ private fun MyPageScreen(
     myPageTabs: List<String>,
     pagerState: PagerState,
     onGroupDetailButtonClick: (Int, String) -> Unit,
-    onGroupRoomButtonClick: (Int, String) -> Unit
+    onGroupRoomButtonClick: (Int, String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .padding(WindowInsets.navigationBars.asPaddingValues())
     ) {
         CenterTitleTopBar(
             centerTitleResId = R.string.topbar_my_page,


### PR DESCRIPTION
## Related issue 🛠
- closed #27

## Work Description ✏️
- 바텀네비바 사용하는 화면(모임목록, 홈, 마이페이지) innerPadding 적용
- 모임 등록하기 flow중 패딩간격 문제있는 화면 수정

## Screenshot 📸
| as-is | to-be |
|:--:|:--:|
| <img width="" height="580" src="https://github.com/user-attachments/assets/15ee06d0-ae73-4351-a2bb-1c80f1f075d4" > |  <img width="" height="580" src="https://github.com/user-attachments/assets/9ff15930-787b-43e6-b988-7559c5938f51" > |
| <img width="" height="580" src="https://github.com/user-attachments/assets/9d7831e3-84ff-4a36-89db-299358a1c100" > |  <img width="" height="580" src="https://github.com/user-attachments/assets/4f45810e-071b-4511-ade6-c875d63a87bc" > |
| <img width="" height="580" src="" > |  <img width="" height="580" src="https://github.com/user-attachments/assets/f8d58c75-a878-4671-a5cd-094dc271d1bb" > |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 잘못된 패딩 설정으로 화면이 겹치거나, 여백이 생긴 화면들의 패딩값을 조정하여 올바르게 보이도록 수정했습니다!
- 일단 당장 릴리즈에 문제가 될 화면은 없도록 수정했는데, 혹시라도 빠진부분이 있다면 알려주세요~!

- 추가로 작업간에 고민해볼점을 정리해봤는데, 1차 스프린트 이후 고민해보면 좋을거 같습니다!
  - 모임등록하기 flow에 해당하는 화면  중 스크롤을 필요한 화면에 scaffold가 반드시 필요할까?
  - 시스템바 패딩을 0.dp로 설정하여 화면과 겹치는 문제는 어떻게 처리할까?(-> 홈화면 이미지)