### PR TITLE
[Feat/77] 모임상세, 스페이스에서 탈퇴자에 대한 대응을 구현합니다.

### DIFF
--- a/app/src/main/java/com/sopt/gongbaek/data/remote/dto/response/GroupCommentsResponseDto.kt
+++ b/app/src/main/java/com/sopt/gongbaek/data/remote/dto/response/GroupCommentsResponseDto.kt
@@ -14,7 +14,7 @@ data class GroupCommentsResponseDto(
     @Serializable
     data class GroupCommentResponseDto(
         @SerialName("commentId") val commentId: Int,
-        @SerialName("nickname") val nickname: String,
+        @SerialName("nickname") val nickname: String?,
         @SerialName("body") val body: String,
         @SerialName("createdAt") val createdAt: String,
         @SerialName("isGroupHost") val isGroupHost: Boolean,

--- a/app/src/main/java/com/sopt/gongbaek/data/remote/dto/response/GroupMembersResponseDto.kt
+++ b/app/src/main/java/com/sopt/gongbaek/data/remote/dto/response/GroupMembersResponseDto.kt
@@ -12,7 +12,7 @@ data class GroupMembersResponseDto(
     @Serializable
     data class GroupMemberResponseDto(
         @SerialName("profileImg") val profileImg: Int,
-        @SerialName("nickname") val nickname: String,
+        @SerialName("nickname") val nickname: String?,
         @SerialName("isHost") val isHost: Boolean
     )
 }

--- a/app/src/main/java/com/sopt/gongbaek/domain/model/GroupComments.kt
+++ b/app/src/main/java/com/sopt/gongbaek/domain/model/GroupComments.kt
@@ -9,7 +9,7 @@ data class GroupComments(
 ) {
     data class GroupComment(
         val commentId: Int = 0,
-        val commentWriter: String = "",
+        val commentWriter: String? = null,
         val commentContent: String = "",
         val createdAt: String = "",
         val isGroupHost: Boolean = false,

--- a/app/src/main/java/com/sopt/gongbaek/domain/model/GroupHost.kt
+++ b/app/src/main/java/com/sopt/gongbaek/domain/model/GroupHost.kt
@@ -2,7 +2,7 @@ package com.sopt.gongbaek.domain.model
 
 data class GroupHost(
     val profileImg: Int = 0,
-    val nickname: String = "",
+    val nickname: String? = null,
     val gender: String = "",
     val major: String = "",
     val enterYear: Int = 0,

--- a/app/src/main/java/com/sopt/gongbaek/domain/model/GroupMembers.kt
+++ b/app/src/main/java/com/sopt/gongbaek/domain/model/GroupMembers.kt
@@ -7,7 +7,7 @@ data class GroupMembers(
 ) {
     data class Member(
         val profileImg: Int = 0,
-        val nickname: String = "",
+        val nickname: String? = null,
         val isHost: Boolean = false
     )
 }

--- a/app/src/main/java/com/sopt/gongbaek/domain/usecase/LoadGroupDetailScreenUseCase.kt
+++ b/app/src/main/java/com/sopt/gongbaek/domain/usecase/LoadGroupDetailScreenUseCase.kt
@@ -1,6 +1,7 @@
 package com.sopt.gongbaek.domain.usecase
 
 import com.sopt.gongbaek.domain.model.GroupDetail
+import com.sopt.gongbaek.domain.model.GroupHost
 import com.sopt.gongbaek.domain.repository.CommentRepository
 import com.sopt.gongbaek.domain.repository.GroupRepository
 import kotlinx.coroutines.async
@@ -27,11 +28,11 @@ class LoadGroupDetailScreenUseCase(
                 val groupHostResult = groupHostDeferred.await()
                 val groupCommentsResult = groupCommentsDeferred.await()
 
-                if (groupInfoResult.isSuccess && groupHostResult.isSuccess && groupCommentsResult.isSuccess) {
+                if (groupInfoResult.isSuccess && groupCommentsResult.isSuccess) {
                     Result.success(
                         GroupDetail(
                             groupInfo = groupInfoResult.getOrThrow(),
-                            groupHost = groupHostResult.getOrThrow(),
+                            groupHost = groupHostResult.getOrElse { GroupHost() },
                             groupComments = groupCommentsResult.getOrThrow()
                         )
                     )
@@ -39,9 +40,9 @@ class LoadGroupDetailScreenUseCase(
                     Result.failure(
                         Exception(
                             "Failed to load group detail: " +
-                                "GroupInfo=${groupInfoResult.exceptionOrNull()?.message}, " +
-                                "GroupHost=${groupHostResult.exceptionOrNull()?.message}, " +
-                                "GroupComments=${groupCommentsResult.exceptionOrNull()?.message}"
+                                "\nGroupInfo : ${groupInfoResult.exceptionOrNull()?.message}" +
+                                "\nGroupHost : ${groupHostResult.exceptionOrNull()?.message}" +
+                                "\nGroupComments : ${groupCommentsResult.exceptionOrNull()?.message}"
                         )
                     )
                 }

--- a/app/src/main/java/com/sopt/gongbaek/domain/usecase/LoadGroupRoomScreenUseCase.kt
+++ b/app/src/main/java/com/sopt/gongbaek/domain/usecase/LoadGroupRoomScreenUseCase.kt
@@ -39,9 +39,9 @@ class LoadGroupRoomScreenUseCase(
                     Result.failure(
                         Exception(
                             "Failed to load group detail: " +
-                                "GroupInfo=${groupInfoResult.exceptionOrNull()?.message}, " +
-                                "GroupMembers=${groupMembersResult.exceptionOrNull()?.message}, " +
-                                "GroupComments=${groupCommentsResult.exceptionOrNull()?.message}"
+                                "\nGroupInfo=${groupInfoResult.exceptionOrNull()?.message}" +
+                                "\nGroupMembers=${groupMembersResult.exceptionOrNull()?.message}" +
+                                "\nGroupComments=${groupCommentsResult.exceptionOrNull()?.message}"
                         )
                     )
                 }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/section/CommentSection.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/component/section/CommentSection.kt
@@ -160,7 +160,7 @@ private fun CommentSectionItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = groupComment.commentWriter,
+                text = groupComment.commentWriter ?: stringResource(R.string.comment_section_unknown),
                 color = GongBaekTheme.colors.gray10,
                 style = GongBaekTheme.typography.body1.sb16
             )

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupdetail/screen/GroupDetailInfoSection.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/groupdetail/screen/GroupDetailInfoSection.kt
@@ -87,166 +87,195 @@ fun GroupDetailInfoSection(
                 Spacer(modifier = Modifier.height(30.dp))
             }
 
-            item {
-                Column {
-                    Text(
-                        text = stringResource(R.string.group_detail_host_profile_title),
-                        color = GongBaekTheme.colors.gray10,
-                        style = GongBaekTheme.typography.body1.b16
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .roundedBackgroundWithBorder(
-                                cornerRadius = 4.dp,
-                                backgroundColor = GongBaekTheme.colors.gray01
-                            )
-                            .padding(10.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Image(
-                            painter = painterResource(ProfileImageList.getProfileImage(groupHost.profileImg)),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .width((LocalConfiguration.current.screenWidthDp * 0.22).dp)
-                                .aspectRatio(1f / 1f)
-                                .clip(shape = RoundedCornerShape(2.dp))
-                                .roundedBackgroundWithBorder(
-                                    cornerRadius = 2.dp,
-                                    backgroundColor = Color.Transparent,
-                                    borderColor = GongBaekTheme.colors.gray02,
-                                    borderWidth = 1.dp
-                                )
+            if (groupHost.nickname != null) {
+                item {
+                    Column {
+                        Text(
+                            text = stringResource(R.string.group_detail_host_profile_title),
+                            color = GongBaekTheme.colors.gray10,
+                            style = GongBaekTheme.typography.body1.b16
                         )
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Column {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = groupHost.nickname,
-                                    color = GongBaekTheme.colors.gray09,
-                                    style = GongBaekTheme.typography.body1.b16
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .roundedBackgroundWithBorder(
+                                    cornerRadius = 4.dp,
+                                    backgroundColor = GongBaekTheme.colors.gray01
                                 )
-                                when {
-                                    groupHost.gender.isEmpty() -> {}
-                                    else -> {
-                                        when (GenderType.fromName(groupHost.gender)) {
-                                            GenderType.MAN -> Image(
-                                                imageVector = ImageVector.vectorResource(R.drawable.ic_male_20),
-                                                contentDescription = null
-                                            )
+                                .padding(10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Image(
+                                painter = painterResource(ProfileImageList.getProfileImage(groupHost.profileImg)),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .width((LocalConfiguration.current.screenWidthDp * 0.22).dp)
+                                    .aspectRatio(1f / 1f)
+                                    .clip(shape = RoundedCornerShape(2.dp))
+                                    .roundedBackgroundWithBorder(
+                                        cornerRadius = 2.dp,
+                                        backgroundColor = Color.Transparent,
+                                        borderColor = GongBaekTheme.colors.gray02,
+                                        borderWidth = 1.dp
+                                    )
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Column {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        text = groupHost.nickname,
+                                        color = GongBaekTheme.colors.gray09,
+                                        style = GongBaekTheme.typography.body1.b16
+                                    )
+                                    when {
+                                        groupHost.gender.isEmpty() -> {}
+                                        else -> {
+                                            when (GenderType.fromName(groupHost.gender)) {
+                                                GenderType.MAN -> Image(
+                                                    imageVector = ImageVector.vectorResource(R.drawable.ic_male_20),
+                                                    contentDescription = null
+                                                )
 
-                                            GenderType.WOMAN -> Image(
-                                                imageVector = ImageVector.vectorResource(R.drawable.ic_female_20),
-                                                contentDescription = null
-                                            )
+                                                GenderType.WOMAN -> Image(
+                                                    imageVector = ImageVector.vectorResource(R.drawable.ic_female_20),
+                                                    contentDescription = null
+                                                )
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            Spacer(modifier = Modifier.height(6.dp))
-                            Box(
-                                contentAlignment = Alignment.Center,
-                                modifier = Modifier.roundedBackgroundWithBorder(
-                                    cornerRadius = 4.dp,
-                                    backgroundColor = GongBaekTheme.colors.gray09
-                                )
-                            ) {
-                                Text(
-                                    text = groupHost.major,
-                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                    color = GongBaekTheme.colors.gray01,
-                                    style = GongBaekTheme.typography.caption2.m12
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(6.dp))
-                            FlowRow(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                verticalArrangement = Arrangement.spacedBy(6.dp)
-                            ) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                    verticalAlignment = Alignment.CenterVertically
+                                Spacer(modifier = Modifier.height(6.dp))
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier = Modifier.roundedBackgroundWithBorder(
+                                        cornerRadius = 4.dp,
+                                        backgroundColor = GongBaekTheme.colors.gray09
+                                    )
                                 ) {
-                                    Box(
-                                        contentAlignment = Alignment.Center,
-                                        modifier = Modifier.roundedBackgroundWithBorder(
-                                            cornerRadius = 4.dp,
-                                            backgroundColor = GongBaekTheme.colors.white
-                                        )
-                                    ) {
-                                        Text(
-                                            text = stringResource(R.string.group_detail_enter_year_title),
-                                            modifier = Modifier.padding(
-                                                horizontal = 6.dp,
-                                                vertical = 1.dp
-                                            ),
-                                            color = GongBaekTheme.colors.mainOrange,
-                                            style = GongBaekTheme.typography.caption2.m12
-                                        )
-                                    }
                                     Text(
-                                        text = stringResource(
-                                            R.string.group_detail_enter_year,
-                                            formatEnterYearToString(groupHost.enterYear)
-                                        ),
-                                        color = GongBaekTheme.colors.gray08,
+                                        text = groupHost.major,
+                                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
+                                        color = GongBaekTheme.colors.gray01,
                                         style = GongBaekTheme.typography.caption2.m12
                                     )
                                 }
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                    verticalAlignment = Alignment.CenterVertically
+                                Spacer(modifier = Modifier.height(6.dp))
+                                FlowRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    verticalArrangement = Arrangement.spacedBy(6.dp)
                                 ) {
-                                    Box(
-                                        contentAlignment = Alignment.Center,
-                                        modifier = Modifier.roundedBackgroundWithBorder(
-                                            cornerRadius = 4.dp,
-                                            backgroundColor = GongBaekTheme.colors.white
-                                        )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                        verticalAlignment = Alignment.CenterVertically
                                     ) {
+                                        Box(
+                                            contentAlignment = Alignment.Center,
+                                            modifier = Modifier.roundedBackgroundWithBorder(
+                                                cornerRadius = 4.dp,
+                                                backgroundColor = GongBaekTheme.colors.white
+                                            )
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.group_detail_enter_year_title),
+                                                modifier = Modifier.padding(
+                                                    horizontal = 6.dp,
+                                                    vertical = 1.dp
+                                                ),
+                                                color = GongBaekTheme.colors.mainOrange,
+                                                style = GongBaekTheme.typography.caption2.m12
+                                            )
+                                        }
                                         Text(
-                                            text = stringResource(R.string.group_detail_mbti_title),
-                                            modifier = Modifier.padding(
-                                                horizontal = 6.dp,
-                                                vertical = 1.dp
+                                            text = stringResource(
+                                                R.string.group_detail_enter_year,
+                                                formatEnterYearToString(groupHost.enterYear)
                                             ),
-                                            color = GongBaekTheme.colors.mainOrange,
+                                            color = GongBaekTheme.colors.gray08,
                                             style = GongBaekTheme.typography.caption2.m12
                                         )
                                     }
-                                    Text(
-                                        text = groupHost.mbti,
-                                        color = GongBaekTheme.colors.gray08,
-                                        style = GongBaekTheme.typography.caption2.m12
-                                    )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Box(
+                                            contentAlignment = Alignment.Center,
+                                            modifier = Modifier.roundedBackgroundWithBorder(
+                                                cornerRadius = 4.dp,
+                                                backgroundColor = GongBaekTheme.colors.white
+                                            )
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.group_detail_mbti_title),
+                                                modifier = Modifier.padding(
+                                                    horizontal = 6.dp,
+                                                    vertical = 1.dp
+                                                ),
+                                                color = GongBaekTheme.colors.mainOrange,
+                                                style = GongBaekTheme.typography.caption2.m12
+                                            )
+                                        }
+                                        Text(
+                                            text = groupHost.mbti,
+                                            color = GongBaekTheme.colors.gray08,
+                                            style = GongBaekTheme.typography.caption2.m12
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
+                    Spacer(modifier = Modifier.height(10.dp))
                 }
-                Spacer(modifier = Modifier.height(10.dp))
-            }
 
-            item {
-                Box(
-                    modifier = Modifier.roundedBackgroundWithBorder(
-                        cornerRadius = 4.dp,
-                        backgroundColor = GongBaekTheme.colors.gray01
-                    )
-                ) {
-                    Text(
-                        text = groupHost.introduction,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        color = GongBaekTheme.colors.gray08,
-                        style = GongBaekTheme.typography.body2.r14
-                    )
+                item {
+                    Box(
+                        modifier = Modifier.roundedBackgroundWithBorder(
+                            cornerRadius = 4.dp,
+                            backgroundColor = GongBaekTheme.colors.gray01
+                        )
+                    ) {
+                        Text(
+                            text = groupHost.introduction,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            color = GongBaekTheme.colors.gray08,
+                            style = GongBaekTheme.typography.body2.r14
+                        )
+                    }
+                }
+            } else {
+                item {
+                    Column {
+                        Text(
+                            text = stringResource(R.string.group_detail_host_profile_title),
+                            color = GongBaekTheme.colors.gray10,
+                            style = GongBaekTheme.typography.body1.b16
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Box(
+                            modifier = Modifier
+                                .roundedBackgroundWithBorder(
+                                    cornerRadius = 4.dp,
+                                    backgroundColor = GongBaekTheme.colors.gray01
+                                )
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "탈퇴한 회원입니다.",
+                                modifier = Modifier.fillMaxWidth(),
+                                color = GongBaekTheme.colors.gray08,
+                                style = GongBaekTheme.typography.body2.r14
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouproom/screen/GroupRoomScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/grouproom/screen/GroupRoomScreen.kt
@@ -308,7 +308,7 @@ private fun GroupRoomPeopleSection(
                     }
                     Spacer(modifier = Modifier.height(6.dp))
                     Text(
-                        text = member.nickname,
+                        text = member.nickname ?: stringResource(R.string.grouproom_member_unknown),
                         color = GongBaekTheme.colors.gray10,
                         overflow = TextOverflow.Ellipsis,
                         maxLines = 1,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="comment_section_header">댓글 %1$s개</string>
     <string name="comment_section_empty_description">아직 댓글이 없어요!\n궁금한 것을 댓글로 작성해주세요.</string>
     <string name="comment_section_comment_writer_chip">모집자</string>
+    <string name="comment_section_unknown">알 수 없음</string>
     <string name="comment_section_text_field_placeholder">댓글을 작성해주세요.</string>
 
     <!--GroupInfoChip-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <!-- GroupRoomScreen-->
     <string name="grouproom_people_count">멤버 (%1$s/%2$s명)</string>
     <string name="grouproom_people_chip_host">모집자</string>
+    <string name="grouproom_member_unknown">알 수 없음</string>
 
     <!--SelectDayCalendar-->
     <string name="select_day_calendar_year_month">%1$d년 %2$d월</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #77 

## Work Description ✏️
**모임상세 탈퇴자 대응**
- 생성자가 탈퇴했을 경우 -> 모집자 프로필에 "탈퇴한 회원입니다."

**스페이스 탈퇴자 대응** 
- 탈퇴한 회원의 이름을 "알 수 없음"으로 표시 

**댓글 부분**
- 탈퇴한 회원의 이름을 "알 수 없음"으로 표시

## Screenshot 📸
| 모임상세 탈퇴자 대응 | 댓글 부분 탈퇴자 대응 |
| --- | --- |
| <img width="306" alt="스크린샷 2025-05-15 오전 12 48 20" src="https://github.com/user-attachments/assets/34b41b7b-e75d-44ee-82d1-9db5db73a945" /> | <img width="307" alt="스크린샷 2025-05-15 오전 12 48 39" src="https://github.com/user-attachments/assets/f00dddf8-3953-4952-9acb-38256ec9fe36" /> |

## Uncompleted Tasks 😅
- [x] 스페이스 탈퇴자 대응은 미완료입니다. 모임 생성자/신청자 상관없이 탈퇴하면 모임 신청이 취소되는 로직으로 서버에서 구현 중입니다. 따라서 탈퇴자는 멤버 조회 자체에 잡히지 않기에 탈퇴한 회원의 이름을 "알 수 없음"으로 표시할 수 없게 되었습니다.
- [x] 또한 댓글 부분에서 모집자가 탈퇴했을 경우, isHost가 false가 되어서 오기때문에 모집자 태그 대응이 불가능합니다.

## To Reviewers 📢
- N/A