### PR TITLE
[Feat/84] "홈", "회원가입" 사용자 UX를 개선합니다.

### DIFF
--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/EmailVerificationScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/EmailVerificationScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +46,7 @@ import com.sopt.gongbaek.presentation.ui.component.button.GongBaekButton
 import com.sopt.gongbaek.presentation.ui.component.button.GongBaekButtonDefault
 import com.sopt.gongbaek.presentation.ui.component.progressBar.GongBaekProgressBar
 import com.sopt.gongbaek.presentation.ui.component.topbar.StartTitleTopBar
+import com.sopt.gongbaek.presentation.util.extension.clickableWithoutRipple
 import com.sopt.gongbaek.presentation.util.formatTimeLeft
 import com.sopt.gongbaek.ui.theme.GongBaekTheme
 
@@ -101,6 +103,8 @@ private fun EmailVerificationScreen(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val focusManager = LocalFocusManager.current
+
     Column(
         modifier = modifier.fillMaxSize()
     ) {
@@ -110,6 +114,9 @@ private fun EmailVerificationScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .clickableWithoutRipple {
+                    focusManager.clearFocus()
+                }
                 .padding(horizontal = 16.dp)
         ) {
             Column {

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/MajorSearchScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/MajorSearchScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -96,6 +97,8 @@ private fun MajorSearchScreen(
     onCloseClick: () -> Unit,
     onComplete: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
+
     Scaffold(
         topBar = {
             CenterTitleTopBar(
@@ -129,35 +132,43 @@ private fun MajorSearchScreen(
         },
         containerColor = GongBaekTheme.colors.white,
         content = { paddingValues ->
-            Column(
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(top = 12.dp)
+                    .clickableWithoutRipple {
+                        focusManager.clearFocus()
+                    }
             ) {
-                SearchTextField(
-                    value = academicInfoState.majorSearchQuery,
-                    onValueChange = onSearchQueryChanged,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    onSearchButtonClicked = onSearchButtonClicked
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = 12.dp)
+                ) {
+                    SearchTextField(
+                        value = academicInfoState.majorSearchQuery,
+                        onValueChange = onSearchQueryChanged,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        onSearchButtonClicked = onSearchButtonClicked
+                    )
 
-                Spacer(modifier = Modifier.height(14.dp))
+                    Spacer(modifier = Modifier.height(14.dp))
 
-                val keyboardController = LocalSoftwareKeyboardController.current
-                val majors = academicInfoState.searchedMajors
-                when {
-                    majors == null -> {}
-                    majors.isEmpty() -> EmptySearchResultView()
-                    else -> {
-                        SearchResultSection(
-                            searchResults = majors,
-                            selectedItem = academicInfoState.major,
-                            onItemSelected = { query ->
-                                keyboardController?.hide()
-                                onMajorSelected(query)
-                            }
-                        )
+                    val keyboardController = LocalSoftwareKeyboardController.current
+                    val majors = academicInfoState.searchedMajors
+                    when {
+                        majors == null -> {}
+                        majors.isEmpty() -> EmptySearchResultView()
+                        else -> {
+                            SearchResultSection(
+                                searchResults = majors,
+                                selectedItem = academicInfoState.major,
+                                onItemSelected = { query ->
+                                    keyboardController?.hide()
+                                    onMajorSelected(query)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/NicknameGenderScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/NicknameGenderScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,7 @@ import com.sopt.gongbaek.presentation.ui.component.progressBar.GongBaekProgressB
 import com.sopt.gongbaek.presentation.ui.component.section.PageDescriptionSection
 import com.sopt.gongbaek.presentation.ui.component.textfield.GongBaekBasicTextField
 import com.sopt.gongbaek.presentation.ui.component.topbar.StartTitleTopBar
+import com.sopt.gongbaek.presentation.util.extension.clickableWithoutRipple
 import com.sopt.gongbaek.ui.theme.GongBaekTheme
 
 @Composable
@@ -78,8 +80,13 @@ private fun NicknameGenderScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     Box(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .clickableWithoutRipple {
+                focusManager.clearFocus()
+            }
     ) {
         NickNameInputSection(
             nickname = uiState.nickname,

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/SelfIntroductionScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/SelfIntroductionScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -30,6 +31,7 @@ import com.sopt.gongbaek.presentation.ui.component.progressBar.GongBaekProgressB
 import com.sopt.gongbaek.presentation.ui.component.section.PageDescriptionSection
 import com.sopt.gongbaek.presentation.ui.component.textfield.GongBaekBasicTextField
 import com.sopt.gongbaek.presentation.ui.component.topbar.StartTitleTopBar
+import com.sopt.gongbaek.presentation.util.extension.clickableWithoutRipple
 import com.sopt.gongbaek.ui.theme.GONGBAEKTheme
 import com.sopt.gongbaek.ui.theme.GongBaekTheme
 
@@ -77,8 +79,13 @@ private fun SelfIntroductionScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     Box(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .clickableWithoutRipple {
+                focusManager.clearFocus()
+            }
     ) {
         SelfIntroductionSection(
             selfIntroduction = uiState.selfIntroduction,

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/UnivSearchScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/auth/screen/UnivSearchScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -93,6 +94,8 @@ private fun UnivSearchScreen(
     onCloseClick: () -> Unit,
     onComplete: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
+
     Scaffold(
         topBar = {
             CenterTitleTopBar(
@@ -114,35 +117,43 @@ private fun UnivSearchScreen(
         },
         containerColor = GongBaekTheme.colors.white,
         content = { paddingValues ->
-            Column(
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(top = 12.dp)
+                    .clickableWithoutRipple {
+                        focusManager.clearFocus()
+                    }
             ) {
-                SearchTextField(
-                    value = academicInfoState.universitySearchQuery,
-                    onValueChange = onSearchQueryChanged,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    onSearchButtonClicked = onSearchButtonClicked
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = 12.dp)
+                ) {
+                    SearchTextField(
+                        value = academicInfoState.universitySearchQuery,
+                        onValueChange = onSearchQueryChanged,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        onSearchButtonClicked = onSearchButtonClicked
+                    )
 
-                Spacer(modifier = Modifier.height(14.dp))
+                    Spacer(modifier = Modifier.height(14.dp))
 
-                val keyboardController = LocalSoftwareKeyboardController.current
-                val universities = academicInfoState.searchedUniversities
-                when {
-                    universities == null -> {}
-                    universities.isEmpty() -> EmptySearchResultView()
-                    else -> {
-                        SearchResultSection(
-                            searchResults = universities,
-                            selectedItem = academicInfoState.university,
-                            onItemSelected = { query ->
-                                keyboardController?.hide()
-                                onUniversitySelected(query)
-                            }
-                        )
+                    val keyboardController = LocalSoftwareKeyboardController.current
+                    val universities = academicInfoState.searchedUniversities
+                    when {
+                        universities == null -> {}
+                        universities.isEmpty() -> EmptySearchResultView()
+                        else -> {
+                            SearchResultSection(
+                                searchResults = universities,
+                                selectedItem = academicInfoState.university,
+                                onItemSelected = { query ->
+                                    keyboardController?.hide()
+                                    onUniversitySelected(query)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
@@ -1,5 +1,8 @@
 package com.sopt.gongbaek.presentation.ui.home.screen
 
+import android.app.Activity
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -7,7 +10,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -23,6 +33,8 @@ import com.sopt.gongbaek.presentation.ui.home.component.section.OnceRecommendSec
 import com.sopt.gongbaek.presentation.ui.home.component.section.WeekRecommendSection
 import com.sopt.gongbaek.presentation.util.base.UiLoadState
 import com.sopt.gongbaek.ui.theme.GONGBAEKTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun HomeRoute(
@@ -34,6 +46,25 @@ fun HomeRoute(
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    var backPressedOnce by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val activity = context as? Activity
+    val scope = rememberCoroutineScope()
+
+    BackHandler {
+        if (backPressedOnce) {
+            activity?.finish()
+        } else {
+            backPressedOnce = true
+            Toast.makeText(context, "뒤로 버튼을 한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
+
+            scope.launch {
+                delay(2000L)
+                backPressedOnce = false
+            }
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
@@ -55,7 +55,7 @@ fun HomeRoute(
             activity?.finish()
         } else {
             backPressedOnce = true
-            Toast.makeText(context, "뒤로 버튼을 한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, "뒤로가기를 한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
 
             scope.launch {
                 delay(2000L)

--- a/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/gongbaek/presentation/ui/home/screen/HomeScreen.kt
@@ -10,11 +10,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext


### PR DESCRIPTION
## Related issue 🛠
- closed #84 

## Work Description ✏️
- 홈화면 backHandler 통해 뒤로가기 시 앱 종료 구현
- 회원가입 flow 내 텍스트 필드 포커스 해제 구현

## Screenshot 📸
https://github.com/user-attachments/assets/bd73b7a7-518d-4470-ad44-1c470c0695fe

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
홈 화면 종료 구현하는 김에 한번 언급이 있었던 텍스트 필드 포커스 해제하는 기능도 같이 구현했습니다.

추가로 홈 화면 바텀 네비간 스택 관련해서 다른 앱 보며 레퍼런스를 찾아봤는데 바텀네비 간에는 뒤로가기 시 무조건 홈으로 이동하는 앱들이 많더라고요. 논의 후 추후 적용해보는것도 좋을거 같습니담! (바텀네비 5개 정도 되면? ㅋㅋㅎㅋ)