### PR TITLE
[Refactor/92] 타이포그래피 시스템을 리펙토링 합니다.

### DIFF
--- a/app/src/main/java/com/gongbaek/android/ui/theme/Type.kt
+++ b/app/src/main/java/com/gongbaek/android/ui/theme/Type.kt
@@ -5,15 +5,17 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.gongbaek.android.R
 
-object PretendardFont {
-    val Bold = FontFamily(Font(R.font.pretendard_bold))
-    val SemiBold = FontFamily(Font(R.font.pretendard_semibold))
-    val Medium = FontFamily(Font(R.font.pretendard_medium))
-    val Regular = FontFamily(Font(R.font.pretendard_regular))
-}
+private val PretendardFont = FontFamily(
+    Font(R.font.pretendard_bold, weight = FontWeight.Bold),
+    Font(R.font.pretendard_semibold, weight = FontWeight.SemiBold),
+    Font(R.font.pretendard_medium, weight = FontWeight.Medium),
+    Font(R.font.pretendard_regular, weight = FontWeight.Normal)
+)
+
 
 sealed interface TypographyTokens {
     @Immutable
@@ -89,7 +91,8 @@ data class GongBaekTypography(
 val defaultGongBaekTypography = GongBaekTypography(
     head1 = TypographyTokens.Head1(
         b30 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 30.sp,
             lineHeight = 30.sp,
             letterSpacing = (-1).sp
@@ -97,19 +100,22 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     head2 = TypographyTokens.Head2(
         b24 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 24.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
         ),
         m24 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 24.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
         ),
         r24 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 24.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
@@ -117,19 +123,22 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     title1 = TypographyTokens.Title1(
         b20 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 20.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
         ),
         m20 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 20.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
         ),
         r20 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 20.sp,
             lineHeight = 26.sp,
             letterSpacing = (-1).sp
@@ -137,25 +146,29 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     title2 = TypographyTokens.Title2(
         b18 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 18.sp,
             lineHeight = 22.sp,
             letterSpacing = (-0.5).sp
         ),
         sb18 = TextStyle(
-            fontFamily = PretendardFont.SemiBold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.SemiBold,
             fontSize = 18.sp,
             lineHeight = 22.sp,
             letterSpacing = (-0.5).sp
         ),
         m18 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 18.sp,
             lineHeight = 22.sp,
             letterSpacing = (-0.5).sp
         ),
         r18 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 18.sp,
             lineHeight = 22.sp,
             letterSpacing = (-0.5).sp
@@ -163,25 +176,29 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     body1 = TypographyTokens.Body1(
         b16 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 16.sp,
             lineHeight = 20.sp,
             letterSpacing = (-0.5).sp
         ),
         sb16 = TextStyle(
-            fontFamily = PretendardFont.SemiBold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,
             lineHeight = 20.sp,
             letterSpacing = (-0.5).sp
         ),
         m16 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 16.sp,
             lineHeight = 20.sp,
             letterSpacing = (-0.5).sp
         ),
         r16 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 16.sp,
             lineHeight = 20.sp,
             letterSpacing = (-0.5).sp
@@ -189,25 +206,29 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     body2 = TypographyTokens.Body2(
         b14 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 14.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         sb14 = TextStyle(
-            fontFamily = PretendardFont.SemiBold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.SemiBold,
             fontSize = 14.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         m14 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 14.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         r14 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 14.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
@@ -215,19 +236,22 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     caption1 = TypographyTokens.Caption1(
         sb13 = TextStyle(
-            fontFamily = PretendardFont.SemiBold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.SemiBold,
             fontSize = 13.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         m13 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 13.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         r13 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 13.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
@@ -235,19 +259,22 @@ val defaultGongBaekTypography = GongBaekTypography(
     ),
     caption2 = TypographyTokens.Caption2(
         b12 = TextStyle(
-            fontFamily = PretendardFont.Bold,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Bold,
             fontSize = 12.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         m12 = TextStyle(
-            fontFamily = PretendardFont.Medium,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Medium,
             fontSize = 12.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp
         ),
         r12 = TextStyle(
-            fontFamily = PretendardFont.Regular,
+            fontFamily = PretendardFont,
+            fontWeight = FontWeight.Normal,
             fontSize = 12.sp,
             lineHeight = 18.sp,
             letterSpacing = (-0.5).sp

--- a/app/src/main/java/com/gongbaek/android/ui/theme/Type.kt
+++ b/app/src/main/java/com/gongbaek/android/ui/theme/Type.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.sp
 import com.gongbaek.android.R
 
@@ -16,6 +17,10 @@ private val PretendardFont = FontFamily(
     Font(R.font.pretendard_regular, weight = FontWeight.Normal)
 )
 
+private val PretendardLineHeightStyle = LineHeightStyle(
+    alignment = LineHeightStyle.Alignment.Center,
+    trim = LineHeightStyle.Trim.None
+)
 
 sealed interface TypographyTokens {
     @Immutable
@@ -95,7 +100,8 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 30.sp,
             lineHeight = 30.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     head2 = TypographyTokens.Head2(
@@ -104,21 +110,24 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 24.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m24 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 24.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r24 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 24.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     title1 = TypographyTokens.Title1(
@@ -127,21 +136,24 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 20.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m20 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 20.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r20 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 20.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).sp
+            letterSpacing = (-1).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     title2 = TypographyTokens.Title2(
@@ -150,28 +162,32 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         sb18 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.SemiBold,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m18 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r18 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     body1 = TypographyTokens.Body1(
@@ -180,28 +196,32 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 16.sp,
             lineHeight = 20.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         sb16 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,
             lineHeight = 20.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m16 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 16.sp,
             lineHeight = 20.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r16 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 16.sp,
             lineHeight = 20.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     body2 = TypographyTokens.Body2(
@@ -210,28 +230,32 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 14.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         sb14 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.SemiBold,
             fontSize = 14.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m14 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 14.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r14 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 14.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     caption1 = TypographyTokens.Caption1(
@@ -240,21 +264,24 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.SemiBold,
             fontSize = 13.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m13 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 13.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r13 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 13.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     ),
     caption2 = TypographyTokens.Caption2(
@@ -263,21 +290,24 @@ val defaultGongBaekTypography = GongBaekTypography(
             fontWeight = FontWeight.Bold,
             fontSize = 12.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         m12 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         ),
         r12 = TextStyle(
             fontFamily = PretendardFont,
             fontWeight = FontWeight.Normal,
             fontSize = 12.sp,
             lineHeight = 18.sp,
-            letterSpacing = (-0.5).sp
+            letterSpacing = (-0.5).sp,
+            lineHeightStyle = PretendardLineHeightStyle
         )
     )
 )


### PR DESCRIPTION
## Related issue 🛠
- closed #92 

## Work Description ✏️
- 피그마 디자인과 실기기간의 디자인 불일치 문제 해결했습니다. [43a52fbed2fd6fb0c4fdee5d864b145940c233e9]
  - Compose에서 text의 가장 상단과 하단의 여백을 제거가 됨을 확인할 수 있습니다. 이 때문에 발생하는 피그마와의 디자인 불일치 문제를 해결하고자 `LineHeightStyle.Trim.None`속성을 통해 상단 하단의 여백을 제거하지 않도록 수정했습니다.
- Pretendard FontFamily 정의 방식을 수정했습니다. [98cced25cc1f67bdb8cb13de4691cf99a1217720]
  - 기존에는 각 폰트 굵기에 해당하는 `FontFamily` 객체를 각각 생성해서 사용하는 방식이였습니다. 또한 `FontFamily` 객체는 font를 리스트 타입으로 저장을 합니다. 결국 불필요한 `FontFamily` 객체가 생성된다고 판단이 되어, 현재와 같이 하나의 `FontFamily`를 할당하고 내부에 굵기에 따른 font를 리스트 타입으로 가질수 있도록 수정했습니다.

## Screenshot 📸
- 노션 트러블 슈팅 참고하시길,,

## Uncompleted Tasks 😅
- 없음,,

## To Reviewers 📢
- 없음,, 궁금한거 질문은 언제나 환영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 앱 전반 텍스트를 단일 폰트 패밀리와 가중치 기반으로 통일해 일관성 향상
  - 모든 타이포그래피에 균일한 줄높이 스타일 적용으로 가독성 및 시각적 안정성 개선
  - 헤드/타이틀/본문/캡션 등 텍스트 계층의 시각적 균형 정교화

- 리팩터
  - 폰트 관리 체계 단순화로 유지보수성 및 확장성 향상
  - 공개 API 변경 없음 (외부 동작 영향 최소화)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->